### PR TITLE
Fix url typo for FiTECH

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -67,7 +67,7 @@ You can also put the unit into an enclosure of your choice.
 
 ![Enclosure mount](mount-enclosure.jpg)
 
-Or buy a [FiTECH](http://www.fi-tech-net) enclosure from Carsten Filmer.
+Or buy a [FiTECH](http://www.fi-tech.net) enclosure from Carsten Filmer.
 
 
 ---


### PR DESCRIPTION
Very simple typo fix for the FiTECH url on the hardware readme page.
